### PR TITLE
WIP adding *untested* implementation of the weights

### DIFF
--- a/R/DataStoreClass.R
+++ b/R/DataStoreClass.R
@@ -194,13 +194,15 @@ DataStore <- R6Class(classname = "DataStore",
     active.bin.sVar = NULL,    # name of active binarized cont sVar, changes as fit/predict is called (bin indicators are temp. stored in mat.bin.sVar)
     mat.bin.sVar = NULL,       # temp storage mat for bin indicators on currently binarized continous sVar (from self$active.bin.sVar)
     ord.sVar = NULL,           # Ordinal (cat) transform for continous sVar
+    weights = NULL,
 
-    initialize = function(input_data, X, Y, auto_typing = TRUE, max_n_cat = 20, ...) {
+    initialize = function(input_data, X, Y, auto_typing = TRUE, max_n_cat = 20, weights = NULL, ...) {
       if (!is.data.table(input_data)) data.table::setDT(input_data)
       self$dat.sVar <- input_data
       self$nodes <- list(X = X, Y = Y)
 
       self$max_n_cat <- max_n_cat
+      self$weights <- weights
 
       ## We need to evaluate the types of OUTCOME VARIABLES ONLY (the types of predictors are irrelevant)
       if (auto_typing) self$def.types.sVar(Y = Y) # Define the type of each Y: bin, cat or cont
@@ -331,7 +333,7 @@ DataStore <- R6Class(classname = "DataStore",
     },
 
     get.outvar = function(rowsubset = TRUE, var) {
-      if (length(self$nodes) < 1) stop("DataStore$nodes list is empty!")
+      # if (length(self$nodes) < 1) stop("DataStore$nodes list is empty!")
 
       if (var %in% self$names.sWsA) {
         out <- self$dat.sWsA[rowsubset, var, with = FALSE]
@@ -349,6 +351,14 @@ DataStore <- R6Class(classname = "DataStore",
         return(out)
       }
 
+    },
+
+    get.wts = function(rowsubset = TRUE) {
+      if (!is.null(self$weights)) {
+        return(self$get.outvar(rowsubset, self$weights))
+      } else {
+        return(NULL)
+      }
     },
 
     # Need to find a way to over-ride nbins for categorical vars (allowing it to be set to more than gvars$max_n_cat)!

--- a/R/RegressionClass.R
+++ b/R/RegressionClass.R
@@ -117,6 +117,7 @@ RegressionClass <- R6Class("RegressionClass",
                                    # CAN BE QUERIED BY BinOutModel$predictAeqa() as: intrvls.width[outvar]
     intrvls = NULL,                # Vector of numeric cutoffs defining the bins or a named list of numeric intervals (for length(self$outvar) > 1)
     levels = NULL,
+    weights = NULL,
     # family = NULL,               # (NOT IMPLEMENTED) to run w/ other than "binomial" family
     # form = NULL,                 # (NOT IMPLEMENTED) reg formula, if provided run using the usual glm / speedglm functions
     # Adding ReplMisVal0 = TRUE below for case sA = (netA, sA[j]) with sA[j] continuous, was causing an error otherwise
@@ -130,7 +131,8 @@ RegressionClass <- R6Class("RegressionClass",
                           bin_bymass = TRUE,
                           bin_bydhist = FALSE,
                           max_nperbin = 1000,
-                          pool = FALSE
+                          pool = FALSE,
+                          weights = weights
                           ) {
 
       assert_that(length(outvar.class) == length(outvar))
@@ -155,6 +157,7 @@ RegressionClass <- R6Class("RegressionClass",
       self$bin_bydhist <- bin_bydhist
       self$max_nperbin <- max_nperbin
       self$pool <- pool
+      self$weights <- weights
 
       if (!missing(intrvls)) {
         if (!is.null(intrvls)) {
@@ -278,7 +281,9 @@ RegressionClass <- R6Class("RegressionClass",
       list(outvar.class = self$outvar.class,
           outvar = self$outvar,
           predvars = self$predvars,
-          subset = self$subset)
+          subset = self$subset, 
+          pool = self$pool,
+          weights = self$weights)
     }
   )
 )

--- a/R/fit.R
+++ b/R/fit.R
@@ -39,6 +39,7 @@
 #' When this argument is used it will over-ride automatic bin selection. This options should be
 #' only used when fine-tuned control over bin definitions is desired.
 #' @param verbose Set to \code{TRUE} to print messages on status and information to the console.
+#' @param weights Specify the column in the input data containing the optional weights.
 #' Turn this on by default using \code{options(condensier.verbose=TRUE)}.
 #'
 #' @section Details:
@@ -182,6 +183,7 @@ fit_density <- function(
                       parfit = FALSE,
                       bin_estimator = speedglmR6$new(),
                       intrvls = NULL,
+                      weights = NULL,
                       verbose = getOption("condensier.verbose")
                       ) {
 
@@ -195,21 +197,11 @@ fit_density <- function(
   } else { stop("bin_method argument must be either 'equal.len', 'equal.mass' or 'dhist'") }
 
   nbins <- nbins[1L]
-  # opts <- list(
-  #   bin_estimator = bin_estimator,
-  #   bin_method = bin_method,
-  #   parfit = parfit,
-  #   nbins = nbins,
-  #   max_n_cat = max_n_cat,
-  #   pool = pool,
-  #   max_n_bin = max_n_bin
-  # )
-  # gvars$opts <- opts
 
   if (!is.data.table(input_data)) data.table::setDT(input_data)
 
   ## import the input data into internal storage class
-  data_store_obj <- DataStore$new(input_data = input_data, Y = Y, X = X, max_n_cat = max_n_cat)
+  data_store_obj <- DataStore$new(input_data = input_data, Y = Y, X = X, max_n_cat = max_n_cat, weights = weights)
 
   # Find the class of the provided variable
   outcome.class <- data_store_obj$type.sVar[Y]
@@ -225,7 +217,8 @@ fit_density <- function(
                                   bin_bydhist = bin_method%in%"dhist",
                                   max_nperbin = max_n_bin,
                                   pool = pool,
-                                  intrvls = intrvls)
+                                  intrvls = intrvls,
+                                  weights = weights)
                                   # subset = subset_vars)
 
   # Create the conditional density, based on the regression just specified and fit it

--- a/man/fit_density.Rd
+++ b/man/fit_density.Rd
@@ -7,7 +7,7 @@
 fit_density(X, Y, input_data, bin_method = c("equal.mass", "equal.len",
   "dhist"), nbins = 5, max_n_cat = 20, pool = FALSE,
   max_n_bin = NA_integer_, parfit = FALSE,
-  bin_estimator = speedglmR6$new(), intrvls = NULL,
+  bin_estimator = speedglmR6$new(), intrvls = NULL, weights = NULL,
   verbose = getOption("condensier.verbose"))
 }
 \arguments{
@@ -58,8 +58,10 @@ By default the bins are defined automatically (based on the selected binning met
 When this argument is used it will over-ride automatic bin selection. This options should be
 only used when fine-tuned control over bin definitions is desired.}
 
-\item{verbose}{Set to \code{TRUE} to print messages on status and information to the console.
+\item{weights}{Specify the column in the input data containing the optional weights.
 Turn this on by default using \code{options(condensier.verbose=TRUE)}.}
+
+\item{verbose}{Set to \code{TRUE} to print messages on status and information to the console.}
 }
 \value{
 An R6 object of class \code{SummariesModel} containing the conditional density fit(s).


### PR DESCRIPTION
Per @nhejazi and #12 

* This implements the `weights` option throughout  the package for the two available `bin_estimator`s speedglm and glm. 

* The implementation is *untested* and has not been debugged. No test cases have been written yet. 

* The most difficult and potentially error prone use case is when pooling bin hazards into a single regression (`pool=TRUE'). While the weights option should still work in that case, it is a more difficult implementation, and hence, more susceptible to errors: 

https://github.com/osofr/condensier/blob/weights/R/BinOutModelClass.R#L24-L43
